### PR TITLE
Add .gitignore and .gitattributes for repo hygiene. 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,30 +1,22 @@
-# Auto detect text files and perform LF normalization
 * text=auto eol=lf
 
-# ─── Diff drivers ────────────────────────────────────────────
-*.php           diff=php
-*.md            diff=markdown
+*.php text diff=php
 
-# ─── Force LF ────────────────────────────────────────────────
-*.sh            text eol=lf
-Makefile        text eol=lf
-
-# ─── Generated (skip diff and GitHub stats) ──────────────────
-composer.lock   -diff linguist-generated
-
-# ─── Export ignore (excluded from dist archive) ──────────────
-/tests              export-ignore
-/vendor             export-ignore
-/rules              export-ignore
-
-/.github            export-ignore
-/.gitignore         export-ignore
-/.gitattributes     export-ignore
-
-/CLAUDE.md          export-ignore
-/LICENSE            export-ignore
-/Makefile           export-ignore
-/README.md          export-ignore
-/phpunit.xml        export-ignore
-/phpstan.neon.dist  export-ignore
+# Dev-only — excluded from the Packagist tarball
+/.github             export-ignore
+/tests               export-ignore
+/.claude             export-ignore
+/.editorconfig       export-ignore
+/.gitattributes      export-ignore
+/.gitignore          export-ignore
+/phpunit.xml         export-ignore
+/phpunit.xml.dist    export-ignore
+/phpstan.neon        export-ignore
+/phpstan.neon.dist   export-ignore
+/phpcs.xml           export-ignore
+/phpcs.xml.dist      export-ignore
+/infection.json      export-ignore
 /infection.json.dist export-ignore
+/Makefile            export-ignore
+/CONTRIBUTING.md     export-ignore
+/CHANGES.md          export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,20 @@
-.idea
+# Agent/IDE
+.claude/
+.idea/
+.vscode/
+.cursor/
 
-vendor
-report
+# Composer
+/vendor/
+composer.lock
 
-*.lock
-.phpunit.*
+# PHPUnit / coverage
+.phpunit.cache/
+.phpunit.result.cache
+report/
+coverage/
+build/
+
+# OS
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
Prevent agent/IDE folders (.claude, .idea, .vscode) from being versioned and exclude dev-only files (tests, phpstan, phpcs, phpunit configs) from the Packagist tarball via export-ignore.